### PR TITLE
Added "return connected" to the connect function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     package_dir={'':'src'},
     py_modules=['OpenOPC'],
     url='https://github.com/mkwiatkowski/openopc',
-    version="1.3.1",
+    version="1.3.2",
 )

--- a/src/OpenOPC.py
+++ b/src/OpenOPC.py
@@ -260,6 +260,7 @@ class client():
       self._group_server_handles = {}
       self._group_handles_tag = {}
       self._group_hooks = {}
+      return connected
 
    def GUID(self):
       return self._open_guid


### PR DESCRIPTION
Connected was set within the function but was never returned.

Previously the connected function just returned None.

I bumped the setup.py to 1.3.2

Linked to issue raised on Ya-Mouse Repo - https://github.com/ya-mouse/openopc/issues/16